### PR TITLE
Update fs-extra for Node 6 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/andre-meier/broccoli-preprocess-tree",
   "dependencies": {
     "broccoli-writer": "^0.1.1",
-    "fs-extra": "^0.18.4",
+    "fs-extra": "^0.30.0",
     "glob": "^5.0.10",
     "lodash-node": "^3.9.3",
     "preprocess": "^2.1.1",


### PR DESCRIPTION
This allows updating to graceful-f@4, actual minimum required fs-extra version is 0.21.0, but 0.30.0 should work with the same old node versions.